### PR TITLE
snapshot test should resides in a separate testcase 

### DIFF
--- a/lib/mixins/__tests__/__snapshots__/image.test.js.snap
+++ b/lib/mixins/__tests__/__snapshots__/image.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mixins: image img_retina should set arguments to their expected props 1`] = `
+exports[`mixins: image img_retina should match snapshot 1`] = `
 .c0 {
-  background-image: url(foo);
+  background-image: url(/foo);
 }
 
 @media only screen and (-webkit-min-device-pixel-ratio:2), only screen and ( min--moz-device-pixel-ratio:2), only screen and ( -o-min-device-pixel-ratio:2/1), only screen and ( min-device-pixel-ratio:2), only screen and ( min-resolution:192dpi), only screen and ( min-resolution:2dppx) {
   .c0 {
-    background-image: url(bar);
+    background-image: url(/bar);
     background-size: 1em 20px;
   }
 }

--- a/lib/mixins/__tests__/__snapshots__/labels.test.js.snap
+++ b/lib/mixins/__tests__/__snapshots__/labels.test.js.snap
@@ -1,42 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mixin: label label_variant should accept hsl color 1`] = `
-.c0 {
-  background-color: hsl(0,0%,100%);
-}
-
-.c0[href]:hover,
-.c0[href]:focus {
-  background-color: rgb(230,230,230);
-}
-
-<span
-  className="c0"
->
-  styled label
-</span>
-`;
-
-exports[`mixin: label label_variant should accept named color 1`] = `
+exports[`mixin: label label_variant should match snapshot 1`] = `
 .c0 {
   background-color: white;
-}
-
-.c0[href]:hover,
-.c0[href]:focus {
-  background-color: rgb(230,230,230);
-}
-
-<span
-  className="c0"
->
-  styled label
-</span>
-`;
-
-exports[`mixin: label label_variant should accept web color 1`] = `
-.c0 {
-  background-color: #fff;
 }
 
 .c0[href]:hover,

--- a/lib/mixins/__tests__/image.test.js
+++ b/lib/mixins/__tests__/image.test.js
@@ -32,6 +32,13 @@ describe('mixins: image', () => {
       `
       const wrapper = shallow(<Comp />)
       expect(wrapper).toHaveStyleRule('background-image', 'url(foo)')
+    })
+
+    it('should match snapshot', () => {
+      const Comp = styled.div`
+        ${image.img_retina('/foo', '/bar', '1em', '20px')}
+      `
+      const wrapper = shallow(<Comp />)
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/lib/mixins/__tests__/labels.test.js
+++ b/lib/mixins/__tests__/labels.test.js
@@ -4,6 +4,8 @@ import styled from 'styled-components'
 import 'jest-styled-components'
 import React from 'react'
 
+// TODO assert style rule in pseudo selectors
+// wait until 'jest-styled-components' to support this feature
 describe('mixin: label', () => {
   describe('label_variant', () => {
     it('should accept named color', () => {
@@ -12,7 +14,6 @@ describe('mixin: label', () => {
       `
       const wrapper = shallow(<Comp>styled label</Comp>)
       expect(wrapper).toHaveStyleRule('background-color', 'white')
-      expect(wrapper).toMatchSnapshot()
     })
 
     it('should accept web color', () => {
@@ -21,7 +22,6 @@ describe('mixin: label', () => {
       `
       const wrapper = shallow(<Comp>styled label</Comp>)
       expect(wrapper).toHaveStyleRule('background-color', '#fff')
-      expect(wrapper).toMatchSnapshot()
     })
 
     it('should accept hsl color', () => {
@@ -31,6 +31,14 @@ describe('mixin: label', () => {
       `
       const wrapper = shallow(<Comp>styled label</Comp>)
       expect(wrapper).toHaveStyleRule('background-color', hsl)
+    })
+
+    // use snapshot to inspect pseudo selectors for now
+    it('should match snapshot', () => {
+      const Comp = styled.span`
+        ${label.label_variant('white')}
+      `
+      const wrapper = shallow(<Comp>styled label</Comp>)
       expect(wrapper).toMatchSnapshot()
     })
   })


### PR DESCRIPTION
To test for `darken` function, we have to wait until `jest-styled-components` supports pseudo selectors.
Will go with snapshot testing for now